### PR TITLE
Fixed cannot use display error

### DIFF
--- a/go-gopher-gba/gopher.go
+++ b/go-gopher-gba/gopher.go
@@ -75,19 +75,19 @@ func main() {
 func drawGophers() {
 
 	// Display a textual message "Gopher" with Google colors
-	tinyfont.DrawChar(display, &fonts.Bold24pt7b, 36, 60, 'G', gBlue)
-	tinyfont.DrawChar(display, &fonts.Bold24pt7b, 71, 60, 'o', gRed)
-	tinyfont.DrawChar(display, &fonts.Bold24pt7b, 98, 60, 'p', gYellow)
-	tinyfont.DrawChar(display, &fonts.Bold24pt7b, 126, 60, 'h', gGreen)
-	tinyfont.DrawChar(display, &fonts.Bold24pt7b, 154, 60, 'e', gBlue)
-	tinyfont.DrawChar(display, &fonts.Bold24pt7b, 180, 60, 'r', gRed)
+	tinyfont.DrawChar(&display, &fonts.Bold24pt7b, 36, 60, 'G', gBlue)
+	tinyfont.DrawChar(&display, &fonts.Bold24pt7b, 71, 60, 'o', gRed)
+	tinyfont.DrawChar(&display, &fonts.Bold24pt7b, 98, 60, 'p', gYellow)
+	tinyfont.DrawChar(&display, &fonts.Bold24pt7b, 126, 60, 'h', gGreen)
+	tinyfont.DrawChar(&display, &fonts.Bold24pt7b, 154, 60, 'e', gBlue)
+	tinyfont.DrawChar(&display, &fonts.Bold24pt7b, 180, 60, 'r', gRed)
 
 	// Display a "press START button" message - center
-	tinyfont.WriteLine(display, &tinyfont.TomThumb, 85, 90, "Press START button", white)
+	tinyfont.WriteLine(&display, &tinyfont.TomThumb, 85, 90, "Press START button", white)
 
 	// Display two gophers
-	tinyfont.DrawChar(display, &fonts.Regular58pt, 5, 140, 'B', green)
-	tinyfont.DrawChar(display, &fonts.Regular58pt, 195, 140, 'X', red)
+	tinyfont.DrawChar(&display, &fonts.Regular58pt, 5, 140, 'B', green)
+	tinyfont.DrawChar(&display, &fonts.Regular58pt, 195, 140, 'X', red)
 }
 
 func update(interrupt.Interrupt) {
@@ -100,7 +100,7 @@ func update(interrupt.Interrupt) {
 		// Clear display
 		clearScreen()
 		// Display gopher
-		tinyfont.DrawChar(display, &fonts.Regular58pt, x, y, 'B', green)
+		tinyfont.DrawChar(&display, &fonts.Regular58pt, x, y, 'B', green)
 	// Go back to Menu
 	case keySELECT:
 		clearScreen()
@@ -111,44 +111,44 @@ func update(interrupt.Interrupt) {
 		clearScreen()
 		x = x + 10
 		// display gopher at right
-		tinyfont.DrawChar(display, &fonts.Regular58pt, x, y, 'B', green)
+		tinyfont.DrawChar(&display, &fonts.Regular58pt, x, y, 'B', green)
 	// Gopher go to the left
 	case keyLEFT:
 		// Clear display
 		clearScreen()
 		x = x - 10
 		// display gopher at right
-		tinyfont.DrawChar(display, &fonts.Regular58pt, x, y, 'B', green)
+		tinyfont.DrawChar(&display, &fonts.Regular58pt, x, y, 'B', green)
 	// Gopher go to the down
 	case keyDOWN:
 		// Clear display
 		clearScreen()
 		y = y + 10
-		tinyfont.DrawChar(display, &fonts.Regular58pt, x, y, 'B', green)
+		tinyfont.DrawChar(&display, &fonts.Regular58pt, x, y, 'B', green)
 	// Gopher go to the up
 	case keyUP:
 		// Clear display
 		clearScreen()
 		y = y - 10
-		tinyfont.DrawChar(display, &fonts.Regular58pt, x, y, 'B', green)
+		tinyfont.DrawChar(&display, &fonts.Regular58pt, x, y, 'B', green)
 	//Gopher jump
 	case keyA:
 		// Clear display
 		clearScreen()
 		// Display the gopher up
 		y = y - 20
-		tinyfont.DrawChar(display, &fonts.Regular58pt, x, y, 'B', green)
+		tinyfont.DrawChar(&display, &fonts.Regular58pt, x, y, 'B', green)
 		// Clear the display
 		clearScreen()
 		// Display the gopher down
 		y = y + 20
-		tinyfont.DrawChar(display, &fonts.Regular58pt, x, y, 'B', green)
+		tinyfont.DrawChar(&display, &fonts.Regular58pt, x, y, 'B', green)
 	}
 }
 
 func clearScreen() {
 	tinydraw.FilledRectangle(
-		display,
+		&display,
 		int16(0), int16(0),
 		screenWidth, screenHeight,
 		black,


### PR DESCRIPTION
Fixed these errors:
### command-line-arguments
```gopher.go:79:20: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:80:20: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:81:20: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:82:20: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:83:20: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:86:21: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.WriteLine: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:89:20: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:90:20: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:103:21: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:114:21: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:121:21: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:127:21: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:133:21: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:140:21: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:145:21: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinyfont.DrawChar: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
gopher.go:151:3: cannot use display (variable of type machine.DisplayMode3) as drivers.Displayer value in argument to tinydraw.FilledRectangle: machine.DisplayMode3 does not implement drivers.Displayer (method Display has pointer receiver)
```

By changed `display` to `&display`